### PR TITLE
Diff on any kind of response change

### DIFF
--- a/src/main/java/com/deepoove/swagger/diff/compare/PropertyDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/PropertyDiff.java
@@ -49,7 +49,11 @@ public class PropertyDiff {
       missing.addAll(diff.getMissing());
       changed.addAll(diff.getChanged());
     } else if (left != null && right != null && !left.equals(right)) {
-      changed.add(this.convert2ElProperty("Response type", null, null, left));
+      ElProperty elProperty = new ElProperty();
+      elProperty.setEl(String.format("%s -> %s", left.getType(), right.getType()));
+      elProperty.setParentModelName("response");
+      elProperty.setProperty(left);
+      changed.add(elProperty);
     }
     return this;
   }
@@ -78,15 +82,4 @@ public class PropertyDiff {
     this.changed = changed;
   }
 
-  private String buildElString(String parentEl, String propName) {
-    return null == parentEl ? propName : (parentEl + "." + propName);
-  }
-
-  public ElProperty convert2ElProperty(String propName, String parentEl, String parentModel, Property property) {
-    ElProperty pWithPath = new ElProperty();
-    pWithPath.setProperty(property);
-    pWithPath.setEl(buildElString(parentEl, propName));
-    pWithPath.setParentModelName(parentModel);
-    return pWithPath;
-  }
 }

--- a/src/main/java/com/deepoove/swagger/diff/compare/PropertyDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/PropertyDiff.java
@@ -48,6 +48,8 @@ public class PropertyDiff {
       increased.addAll(diff.getIncreased());
       missing.addAll(diff.getMissing());
       changed.addAll(diff.getChanged());
+    } else if (left != null && right != null && !left.equals(right)) {
+      changed.add(this.convert2ElProperty("Response type", null, null, left));
     }
     return this;
   }
@@ -74,5 +76,17 @@ public class PropertyDiff {
 
   public void setChanged(List<ElProperty> changed) {
     this.changed = changed;
+  }
+
+  private String buildElString(String parentEl, String propName) {
+    return null == parentEl ? propName : (parentEl + "." + propName);
+  }
+
+  public ElProperty convert2ElProperty(String propName, String parentEl, String parentModel, Property property) {
+    ElProperty pWithPath = new ElProperty();
+    pWithPath.setProperty(property);
+    pWithPath.setEl(buildElString(parentEl, propName));
+    pWithPath.setParentModelName(parentModel);
+    return pWithPath;
   }
 }

--- a/src/main/java/com/deepoove/swagger/diff/compare/PropertyDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/PropertyDiff.java
@@ -53,6 +53,7 @@ public class PropertyDiff {
       elProperty.setEl(String.format("%s -> %s", left.getType(), right.getType()));
       elProperty.setParentModelName("response");
       elProperty.setProperty(left);
+      elProperty.setResponseTypeChanged(true);
       changed.add(elProperty);
     }
     return this;

--- a/src/main/java/com/deepoove/swagger/diff/model/ChangedOperation.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ChangedOperation.java
@@ -77,7 +77,7 @@ public class ChangedOperation extends ChangedExtensionGroup implements Changed {
   public boolean isDiff() {
     return !addParameters.isEmpty() || !missingParameters.isEmpty()
         || !changedParameter.isEmpty() || !addProps.isEmpty()
-        || !missingProps.isEmpty() || vendorExtensionsAreDiff();
+        || !missingProps.isEmpty() || !changedProps.isEmpty() || vendorExtensionsAreDiff();
   }
   public boolean isDiffProp(  ) {
     return !addProps.isEmpty()

--- a/src/main/java/com/deepoove/swagger/diff/model/ElProperty.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ElProperty.java
@@ -11,6 +11,7 @@ public class ElProperty extends ChangedExtensionGroup {
   private String el;
   private String parentModelName;
   private Property property;
+  private boolean responseTypeChanged;
 
   public Property getProperty() {
     return property;
@@ -36,4 +37,11 @@ public class ElProperty extends ChangedExtensionGroup {
     this.el = el;
   }
 
+  public boolean getResponseTypeChanged() {
+    return responseTypeChanged;
+  }
+
+  public void setResponseTypeChanged(boolean responseTypeChanged) {
+    this.responseTypeChanged = responseTypeChanged;
+  }
 }


### PR DESCRIPTION
### Summary

Don't wanna link HubSpot internal issues here but this came up when we figured that we ignore any changes to model types (as a whole). e.g. `boolean` -> `MyCustomImmutable`.

I managed to get diff output stuff but is currently hardcoded to say `Modified Response type`. WIP to add better messaging. 

@emm035 @zrrobbins 