### PR TITLE
Fix NPE on diffing of Info objects with null fields

### DIFF
--- a/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
@@ -12,7 +12,6 @@ import java.util.function.Function;
 import com.deepoove.swagger.diff.model.ChangedEndpoint;
 import com.deepoove.swagger.diff.model.ChangedExtensionGroup;
 import com.deepoove.swagger.diff.model.Endpoint;
-import com.google.common.annotations.VisibleForTesting;
 
 import io.swagger.models.HttpMethod;
 import io.swagger.models.Info;
@@ -141,7 +140,6 @@ public class SpecificationDiff {
 //    return hasChanges;
 //  }
 
-  @VisibleForTesting
   static boolean infoHasChanges(Info oldInfo, Info newInfo) {
     return hasChanges(oldInfo, newInfo,
             Info::getDescription,

--- a/src/test/java/com/deepoove/swagger/diff/compare/SpecificationDiffTest.java
+++ b/src/test/java/com/deepoove/swagger/diff/compare/SpecificationDiffTest.java
@@ -1,0 +1,69 @@
+package com.deepoove.swagger.diff.compare;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.swagger.models.Info;
+
+public class SpecificationDiffTest {
+
+  @Test
+  public void infoHasChanges_firstInfoNull_returnsTrue() {
+    boolean result = SpecificationDiff.infoHasChanges(
+        null,
+        new Info().description("abc")
+    );
+
+    Assert.assertTrue(result);
+  }
+
+  @Test
+  public void infoHasChanges_secondInfoNull_returnsTrue() {
+    boolean result = SpecificationDiff.infoHasChanges(
+        null,
+        new Info().description("abc")
+    );
+
+    Assert.assertTrue(result);
+  }
+
+  @Test
+  public void infoHasChanges_noDifference_returnsFalse() {
+    boolean result = SpecificationDiff.infoHasChanges(
+        new Info().description("abc"),
+        new Info().description("abc")
+    );
+
+    Assert.assertFalse(result);
+  }
+
+  @Test
+  public void infoHasChanges_withDifference_returnsTrue() {
+    boolean result = SpecificationDiff.infoHasChanges(
+        new Info().description("abc"),
+        new Info().description("def")
+    );
+
+    Assert.assertTrue(result);
+  }
+
+  @Test
+  public void infoHasChanges_withSecondFieldNull_returnsTrue() {
+    boolean result = SpecificationDiff.infoHasChanges(
+        new Info().description("abc"),
+        new Info().description(null)
+    );
+
+    Assert.assertTrue(result);
+  }
+
+  @Test
+  public void infoHasChanges_withFirstFieldNull_returnsTrue() {
+    boolean result = SpecificationDiff.infoHasChanges(
+        new Info().description(null),
+        new Info().description("def")
+    );
+
+    Assert.assertTrue(result);
+  }
+}


### PR DESCRIPTION
Fixes a NPE that was coming from Info objects / their fields being null when trying to determine whether they have any changes. I fixed the bug and added some tests to verify this doesn't backslide.

@zrrobbins 
@elangan 